### PR TITLE
Force the creation of a python3 virtualenv

### DIFF
--- a/awscli-lambda-package_macos.sh
+++ b/awscli-lambda-package_macos.sh
@@ -17,7 +17,7 @@ export ZIP_FILE_NAME="awscli-lambda-layer.zip"
 mkdir ${VIRTUAL_ENV_DIR}
 
 # Initializes a virtual environment in the virtual environment directory
-virtualenv ${VIRTUAL_ENV_DIR}
+virtualenv -p python3 ${VIRTUAL_ENV_DIR}
 
 # Changes current dir to the virtual env directory
 cd ${VIRTUAL_ENV_DIR}/bin/

--- a/awscli-lambda-package_macos.sh
+++ b/awscli-lambda-package_macos.sh
@@ -46,7 +46,7 @@ cd ${LAMBDA_LAYER_DIR}
 
 # Copies aws and its dependencies to the temp directory
 cp ../${VIRTUAL_ENV_DIR}/bin/aws .
-cp -r ../${VIRTUAL_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/ .
+cp -r ../${VIRTUAL_ENV_DIR}/lib/python*/site-packages/ .
 
 # Zips the contents of the temporary directory
 zip -r ../${ZIP_FILE_NAME} *


### PR DESCRIPTION
Pretty straightforward. On Mac OS High Sierra 10.13.6 the created virtualenv was based on Python 2.7.