### PR TITLE
fix(packaging): move python packages to zip root

### DIFF
--- a/awscli-lambda-package_linux.sh
+++ b/awscli-lambda-package_linux.sh
@@ -17,7 +17,7 @@ export ZIP_FILE_NAME="awscli-lambda-layer.zip"
 mkdir ${VIRTUAL_ENV_DIR}
 
 # Initializes a virtual environment in the virtual environment directory
-virtualenv ${VIRTUAL_ENV_DIR}
+virtualenv -p python3 ${VIRTUAL_ENV_DIR}
 
 # Changes current dir to the virtual env directory
 cd ${VIRTUAL_ENV_DIR}/bin/
@@ -46,7 +46,7 @@ cd ${LAMBDA_LAYER_DIR}
 
 # Copies aws and its dependencies to the temp directory
 cp ../${VIRTUAL_ENV_DIR}/bin/aws .
-cp -r ../${VIRTUAL_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/ .
+cp -r ../${VIRTUAL_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/* .
 
 # Zips the contents of the temporary directory
 zip -r ../${ZIP_FILE_NAME} *

--- a/awscli-lambda-package_macos.sh
+++ b/awscli-lambda-package_macos.sh
@@ -17,7 +17,7 @@ export ZIP_FILE_NAME="awscli-lambda-layer.zip"
 mkdir ${VIRTUAL_ENV_DIR}
 
 # Initializes a virtual environment in the virtual environment directory
-virtualenv ${VIRTUAL_ENV_DIR}
+virtualenv -p python3 ${VIRTUAL_ENV_DIR}
 
 # Changes current dir to the virtual env directory
 cd ${VIRTUAL_ENV_DIR}/bin/
@@ -46,7 +46,7 @@ cd ${LAMBDA_LAYER_DIR}
 
 # Copies aws and its dependencies to the temp directory
 cp ../${VIRTUAL_ENV_DIR}/bin/aws .
-cp -r ../${VIRTUAL_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/ .
+cp -r ../${VIRTUAL_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/* .
 
 # Zips the contents of the temporary directory
 zip -r ../${ZIP_FILE_NAME} *


### PR DESCRIPTION
Fix lambda layer zip packaging. Python packages must be at the **root level** of the zip package, instead of in a `site-packages` directory.
**Related issues**: #2 and #3

Also forcing a `python3` virtualenv.